### PR TITLE
feat: cards view instead of table

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -51,7 +51,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input, output, session):
-    wf_tab = pd.read_csv("app/workflowTable.tsv", sep="\t")
+    wf_tab = pd.read_csv(Path(__file__).parent / "workflowTable.tsv", sep="\t")
 
     # TODO: remove to use a fixed theme
     shinyswatch.theme_picker_server()

--- a/app/app.py
+++ b/app/app.py
@@ -26,7 +26,9 @@ app_ui = ui.page_fluid(
             ),
         ),
         # Answer table
-        ui.panel_main(ui.dataframe.output_data_frame("filter")),
+        ui.panel_main(
+            ui.output_ui("workflow_cards")
+            ),
     ),
     # Styling
     ui.include_css(Path(__file__).parent / "static/styles/main.css"),
@@ -38,7 +40,7 @@ app_ui = ui.page_fluid(
                 target="_blank",
             ),
         ),
-        bottom="0%",
+        top="1%",
         right="1%",
     ),
 )
@@ -70,35 +72,13 @@ def server(input, output, session):
             filtered_wf = du.filter_replies(q_name, input[q_name](), filtered_wf)
         return filtered_wf
     
-    # Workflow cards generation
-
-    def generate_cards(filtered_wf):
-        cards = []
-        for i, row in filtered_wf.iterrows():
-            card = ui.card(
-                ui.card_header(
-                    ui.tags.h5(row["Name"]),
-                    ui.tags.h6(row["Type"]),
-                ),
-                ui.card_body(
-                    ui.tags.p(row["Description"]),
-                    ui.tags.p(f"Author: {row['Author']}"),
-                    ui.tags.p(f"Date: {row['Date']}"),
-                    ui.tags.p(f"Tags: {row['Tags']}"),
-                    ui.tags.p(f"Link: {row['Link']}"),
-                ),
-            )
-            cards.append(card)
-        return cards
-    
+    # Render workflow cards
     @output
     @render.ui
     def workflow_cards():
         filtered_wf = filter()
-        wf_cards = generate_cards(filtered_wf)
-        return ui.layout_cards(wf_cards)
-
-
+        cards = du.generate_cards(filtered_wf)
+        return ui.layout_column_wrap(*cards, width=1 / 3)
 
 ### ---------------------------- ###
 

--- a/app/data_utils.py
+++ b/app/data_utils.py
@@ -4,6 +4,7 @@ import pandas as pd
 from typing import Iterable, List, Union, Optional
 from shiny import ui
 from input_data import questions
+from faicons import icon_svg
 
 # Input functions
 
@@ -84,3 +85,26 @@ def filter_goal(answer: str, workflows: pd.DataFrame) -> pd.DataFrame:
         return workflows[(workflows["goal"] == "auto")]
     else:
         return workflows[(workflows["goal"] == "pipeline")]
+
+# Workflow cards generator
+
+def generate_cards(filtered_wf: pd.DataFrame) -> List[ui.card]:
+    """Generate cards for each workflow in the filtered data frame"""
+    cards = []
+    for i, row in filtered_wf.iterrows():
+        cards.append(
+            ui.card(
+                ui.card_header(
+                    ui.tags.img(src=row["icon"], class_="center"),
+                    ),
+                ui.p("Name: ", row["name"], class_="text"),
+                ui.p(icon_svg("code"), row["format"], class_="text"),
+                # TODO: consider if footer can be used for more details
+                # ui.card_footer(
+                #     ui.tags.a(
+                #         "More details",
+                # ),
+                # )
+            )
+        )
+    return cards

--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -16,3 +16,16 @@ a:hover {
 a:active {
     color: black;
 }
+/* center images */
+.center {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: 120px;
+    height: 60px;
+}
+/* text format */
+.text {
+    font: normal normal 13px/1.2 "arial";
+    letter-spacing: 0px;
+}

--- a/app/workflowTable.tsv
+++ b/app/workflowTable.tsv
@@ -1,15 +1,15 @@
-name	language	k8	ML-compatible	containers	format	goal	combo
-AirFlow	Language-agnostic	yes	yes	yes	Python	auto	yes
-Argo	Language-agnostic	yes	yes	yes	YAML	auto	yes
-DVC	Python	no	yes	no	YAML	auto	no
-Dagster	Python	yes-but	yes	yes	Python	auto	no
-Digdag	Language-agnostic	yes	yes-but	yes	YAML	auto	no
-Hamilton	Python	no	yes	no	Python	pipeline	yes
-Kedro	Python	yes	yes-but	yes	Python	pipeline	yes
-Luigi	Python	yes	yes-but	yes	Python	pipeline	yes
-Metaflow	Python	yes-but	yes	yes	Python	pipeline	yes
-Nextflow	Language-agnostic	yes-but	yes	yes	Groovy	pipeline	yes
-Pachyderm	Python	yes	yes	no	YAML	auto	no
-Prefect	Python	yes-but	no	no	Python	auto	no
-Snakemake 	Language-agnostic	yes-but	yes	yes	Python	pipeline	yes
-Targets 	R	no	no	no	R	pipeline	yes
+name	language	k8	ML-compatible	containers	format	goal	combo	icon
+AirFlow	Language-agnostic	yes	yes	yes	Python	auto	yes	https://raw.githubusercontent.com/apache/airflow/b402f8a35633beb4a41e09365a57008c67d377e8/docs/apache-airflow/img/logos/github_repository_social_image.png
+Argo	Language-agnostic	yes	yes	yes	YAML	auto	yes	https://raw.githubusercontent.com/argoproj/argo-workflows/main/docs/assets/argo.png
+DVC	Python	no	yes	no	YAML	auto	no	https://raw.githubusercontent.com/iterative/dvc.org/2ccb7e976f5f5b0696d49a7a85c32fffe6d76ebc/static/img/logos/dvc.svg
+Dagster	Python	yes-but	yes	yes	Python	auto	no	https://raw.githubusercontent.com/dagster-io/dagster/de7fc9b07557b0dfcd94a5fd0ff5aba3837003d1/docs/next/public/assets/logos/dagster-logo.svg
+Digdag	Language-agnostic	yes	yes-but	yes	YAML	auto	no	https://raw.githubusercontent.com/treasure-data/digdag/master/digdag-docs/src/_static/logo/logo-digdag-rec-wt.png
+Hamilton	Python	no	yes	no	Python	pipeline	yes	https://www.tryhamilton.dev/img/hamilton_logo_transparent_bkgrd.ico
+Kedro	Python	yes	yes-but	yes	Python	pipeline	yes	https://raw.githubusercontent.com/kedro-org/kedro-brand-identity/main/horizontal/color/kedro-horizontal-color-on-light.svg
+Luigi	Python	yes	yes-but	yes	Python	pipeline	yes	https://raw.githubusercontent.com/spotify/luigi/master/doc/luigi.png
+Metaflow	Python	yes-but	yes	yes	Python	pipeline	yes	https://raw.githubusercontent.com/Netflix/metaflow/7e0564cbeb480299d7ae4c382aa094ee7207f202/docs/metaflow.svg
+Nextflow	Language-agnostic	yes-but	yes	yes	Groovy	pipeline	yes	https://raw.githubusercontent.com/nextflow-io/trademark/26e6fbc0830b0ff2b1af9df279cd22a48f37e14d/nextflow-logo-bg-light.svg
+Pachyderm	Python	yes	yes	no	YAML	auto	no	https://www.pachyderm.com/wp-content/uploads/2021/12/PachydermFeatured.jpg
+Prefect	Python	yes-but	no	no	Python	auto	no	https://raw.githubusercontent.com/PrefectHQ/prefect/4bf831bf2e7f97f9fcf0f13d9ab9d3e15c804aca/ui/src/assets/logos/prefect-logo-gradient-navy.svg
+Snakemake 	Language-agnostic	yes-but	yes	yes	Python	pipeline	yes	https://raw.githubusercontent.com/snakemake/snakemake/d99b3a0ec43f29da0f2545d9664da4233eeb5e48/docs/_static/logo-snake.svg
+Targets 	R	no	no	no	R	pipeline	yes	https://raw.githubusercontent.com/ropensci/targets/d71b987df49a63402cf416c2403ece306b5f71c1/man/figures/logo.svg

--- a/assets/deploy.R
+++ b/assets/deploy.R
@@ -1,8 +1,0 @@
-# This script creates the workflow explorer webpage
-
-# libraries
-library(shinylive)
-
-# export app to site/ folder
-
-shinylive::export(app_dir = "app/", output_dir = "docs")


### PR DESCRIPTION
This PR implements a view of the matching workflows into cards instead of a table:

![image](https://github.com/sdsc-ordes/workflow-explorer/assets/7497928/6a7e3344-de92-4b5f-ad6d-5587fb604fdf)

## Major

- New function `generate_cards` in `data_utils.py`: takes as input a filtered workflow list and outputs a list of [`ui.card`](https://shiny.posit.co/py/api/core/ui.card.html#shiny.ui.card) elements 
- New function `workflow_cards` in `app.py`: calls the whole pipeline (filtering and card generation) and returns cards in 3 columns

## Minor

- Update to `main.css` to center workflow logos and define font for cards
- Update to `workflowTable.tsv` to include workflow logos (long job but fun)
**Note:** those damn people from Hamilton only have a square PNG so they've been cursed with a stretched logo
- Updated position and link to GitHub repo: from bottom to top of the page, from `SDSC-ORD` to `sdsc-ordes`
- Removed `assets` folder with old R code